### PR TITLE
+ serial device entitlement for macos

### DIFF
--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
It fixes application errors produced by MacOS sandbox:
- Invalid argument, errno = 22
- Invalid argument, errno = 4