### PR TITLE
Fix linux builds for newer kernels

### DIFF
--- a/linux/libserialport/config.h
+++ b/linux/libserialport/config.h
@@ -54,7 +54,7 @@
 /* #undef HAVE_STRUCT_TERMIOS_C_OSPEED */
 
 /* Define to 1 if the system has the type `struct termiox'. */
-#define HAVE_STRUCT_TERMIOX 1
+/* #undef HAVE_STRUCT_TERMIOX */
 
 /* sys/file.h is available. */
 #define HAVE_SYS_FILE_H 1


### PR DESCRIPTION
Fixes #20

Support for TERMIOX was removed from the Linux kernel starting in 2020-12. Apparently (see [linux mailing list](https://www.spinics.net/lists/linux-serial/msg41926.html)), TERMIOX was never used by any linux driver, but libserialport relies on it for some advanced flow control options (see [upstream bug](https://sigrok.org/bugzilla/show_bug.cgi?id=1687)).

Upstream has decided to disable checking for TERMIOX on linux ([patch](https://sigrok.org/gitweb/?p=libserialport.git;a=commit;h=6f9b03e597ea7200eb616a4e410add3dd1690cb1)). The kernel change has been backported to the 5.10 LTS branch, so it doesn't only affect the lastest kernel versions. We should do the same here.