### PR TITLE
Fix HAVE_STRUCT_TERMIOX preventing android from building in new Gradle versions

### DIFF
--- a/android/libserialport/config.h
+++ b/android/libserialport/config.h
@@ -54,7 +54,7 @@
 /* #undef HAVE_STRUCT_TERMIOS_C_OSPEED */
 
 /* Define to 1 if the system has the type `struct termiox'. */
-#define HAVE_STRUCT_TERMIOX 1
+/* #undef HAVE_STRUCT_TERMIOX */
 
 /* sys/file.h is available. */
 #define HAVE_SYS_FILE_H 1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  libserialport: ^0.2.0+3
+  libserialport: ^0.3.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When upgrading `com.android.tools.build:gradle` the flutter build fails with errors simular to #50 and #20:

Output for `flutter build apk`

```text
Installing CMake 3.22.1 in C:\Users\<username>\AppData\Local\Android\sdk\cmake\3.22.1
"Install CMake 3.22.1 (revision: 3.22.1)" complete.
"Install CMake 3.22.1 (revision: 3.22.1)" finished.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_libserialport:buildCMakeRelWithDebInfo[arm64-v8a]'.
> com.android.ide.common.process.ProcessException: ninja: Entering directory `C:\Users\<username>\AppData\Local\Pub\Cache\hosted\pub.dev\flutter_libserialport-0.3.0\android\.cxx\RelWithDebInfo\tb3q581z\arm64-v8a'
  [1/5] Building C object CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/linux_termios.c.o
  FAILED: CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/linux_termios.c.o
  C:\Users\<username>\AppData\Local\Android\Sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe --target=aarch64-none-linux-android21 --sysroot=C:/Users/<username>/AppData/Local/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/windows-x86_64/sysroot -DLIBSERIALPORT_ATBUILD -Dserialport_EXPORTS -IC:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/android/libserialport -IC:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/android/libserialport/../../third_party/libserialport -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fexceptions -O2 -g -DNDEBUG -fPIC -std=c99 -Wall -Wextra -pedantic -Wmissing-prototypes -Wshadow -MD -MT CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/linux_termios.c.o -MF CMakeFiles\serialport.dir\5835b3541bcc6b1f17b22ec1eafcddbd\third_party\libserialport\linux_termios.c.o.d -o CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/linux_termios.c.o -c C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:98:9: error: invalid application of 'sizeof' to an incomplete type 'struct termiox'
          return sizeof(struct termiox);
                 ^     ~~~~~~~~~~~~~~~~
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:98:23: note: forward declaration of 'struct termiox'
          return sizeof(struct termiox);
                               ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:106:15: error: incomplete definition of type 'struct termiox'
          *rts = (termx->x_cflag & RTSXOFF);
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:103:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:106:27: error: use of undeclared identifier 'RTSXOFF'
          *rts = (termx->x_cflag & RTSXOFF);
                                   ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:107:15: error: incomplete definition of type 'struct termiox'
          *cts = (termx->x_cflag & CTSXON);
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:103:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:107:27: error: use of undeclared identifier 'CTSXON'
          *cts = (termx->x_cflag & CTSXON);
                                   ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:108:15: error: incomplete definition of type 'struct termiox'
          *dtr = (termx->x_cflag & DTRXOFF);
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:103:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:108:27: error: use of undeclared identifier 'DTRXOFF'
          *dtr = (termx->x_cflag & DTRXOFF);
                                   ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:109:15: error: incomplete definition of type 'struct termiox'
          *dsr = (termx->x_cflag & DSRXON);
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:103:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:109:27: error: use of undeclared identifier 'DSRXON'
          *dsr = (termx->x_cflag & DSRXON);
                                   ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:118:7: error: incomplete definition of type 'struct termiox'
          termx->x_cflag &= ~(RTSXOFF | CTSXON | DTRXOFF | DSRXON);
          ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:116:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:118:22: error: use of undeclared identifier 'RTSXOFF'
          termx->x_cflag &= ~(RTSXOFF | CTSXON | DTRXOFF | DSRXON);
                              ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:118:32: error: use of undeclared identifier 'CTSXON'
          termx->x_cflag &= ~(RTSXOFF | CTSXON | DTRXOFF | DSRXON);
                                        ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:118:41: error: use of undeclared identifier 'DTRXOFF'
          termx->x_cflag &= ~(RTSXOFF | CTSXON | DTRXOFF | DSRXON);
                                                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:118:51: error: use of undeclared identifier 'DSRXON'
          termx->x_cflag &= ~(RTSXOFF | CTSXON | DTRXOFF | DSRXON);
                                                           ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:121:8: error: incomplete definition of type 'struct termiox'
                  termx->x_cflag |= RTSXOFF;
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:116:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:121:21: error: use of undeclared identifier 'RTSXOFF'
                  termx->x_cflag |= RTSXOFF;
                                    ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:123:8: error: incomplete definition of type 'struct termiox'
                  termx->x_cflag |= CTSXON;
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:116:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:123:21: error: use of undeclared identifier 'CTSXON'
                  termx->x_cflag |= CTSXON;
                                    ^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:125:8: error: incomplete definition of type 'struct termiox'
                  termx->x_cflag |= DTRXOFF;
                  ~~~~~^
  C:/Users/<username>/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.3.0/third_party/libserialport/linux_termios.c:116:9: note: forward declaration of 'struct termiox'
          struct termiox *termx = (struct termiox *) data;
                 ^
  fatal error: too many errors emitted, stopping now [-ferror-limit=]
  20 errors generated.
  [2/5] Building C object CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/timing.c.o
  [3/5] Building C object CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/linux.c.o
  [4/5] Building C object CMakeFiles/serialport.dir/5835b3541bcc6b1f17b22ec1eafcddbd/third_party/libserialport/serialport.c.o
  ninja: build stopped: subcommand failed.

  C++ build system [build] failed while executing:
      @echo off
      "C:\\Users\\<username>\\AppData\\Local\\Android\\sdk\\cmake\\3.22.1\\bin\\ninja.exe" ^
        -C ^
        "C:\\Users\\<username>\\AppData\\Local\\Pub\\Cache\\hosted\\pub.dev\\flutter_libserialport-0.3.0\\android\\.cxx\\RelWithDebInfo\\tb3q581z\\arm64-v8a" ^
        serialport
    from C:\Users\<username>\AppData\Local\Pub\Cache\hosted\pub.dev\flutter_libserialport-0.3.0\android

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5m 13s
```

When commenting out line 57 in `flutter_libserialport-0.2.3/android/libserialport/config.h`:
```c
/* Define to 1 if the system has the type `struct termiox'. */
/* #undef HAVE_STRUCT_TERMIOX */
```
With the following gradle and kotlin config, the build passes again:

andriod\app\build.gradle
```
dependencies {
    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
}
```

android\build.gradle
```
ext.kotlin_version = '1.8.20'
    repositories {
        google()
        mavenCentral()
    }

    dependencies {
        classpath 'com.android.tools.build:gradle:7.4.2'
        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
    }

```