### PR TITLE
Fix: Error when compiling using Flutter 3.29

### DIFF
--- a/android/src/main/kotlin/org/sigrok/flutter_libserialport/FlutterLibserialportPlugin.kt
+++ b/android/src/main/kotlin/org/sigrok/flutter_libserialport/FlutterLibserialportPlugin.kt
@@ -7,7 +7,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** FlutterLibserialportPlugin */
 class FlutterLibserialportPlugin: FlutterPlugin, MethodCallHandler {


### PR DESCRIPTION
When compiling i get this error:

```
e: file:///C:/Users/USERNAME/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_libserialport-0.5.0/android/src/main/kotlin/org/sigrok/flutter_libserialport/FlutterLibserialportPlugin.kt:10:48 Unresolved reference 'Registrar'.
```

Line 10 was this:
```kt
import io.flutter.plugin.common.PluginRegistry.Registrar
```
And because `Registrar` was never used, i simply removed it and got this issue fixed.